### PR TITLE
Update pytest requirement for correct work with pytest-cov plugin

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-pytest==3.2.1
+pytest<4.0.0
 tox==2.7.0
 docker
 pytest-asyncio


### PR DESCRIPTION
Problem: previous merge request test requirements were out of date and broke travis build.

Solution: update pytest version to newest possible without backward-incompatibility.